### PR TITLE
Replace Hawk with Beholder and accept function to determine relevant files

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :deps {hawk/hawk {:mvn/version "0.2.11"}
+ :deps {com.nextjournal/beholder {:mvn/version "1.0.0"}
         integrant/repl {:mvn/version "0.3.2"}
         org.clojure/clojure {:mvn/version "1.10.2"}}
  :aliases {:release

--- a/src/integrant_repl_autoreload/core.clj
+++ b/src/integrant_repl_autoreload/core.clj
@@ -4,25 +4,44 @@
 
 (defonce watcher nil)
 
-(defn- clojure-file? [path]
-  (re-matches #"[^.].*(\.clj\w?|\.edn)$" (-> path .getFileName .toString)))
+(defn- clojure-file? [filename]
+  (re-matches #"[^.].*(\.clj\w?|\.edn)$" filename))
 
-(defn- auto-reset-handler [event]
-  (when (clojure-file? (:path event))
+(defn- auto-reset-handler [relevant-file? event]
+  (when (relevant-file? (-> event :path .getFileName .toString))
     (binding [*ns* *ns*]
       (integrant.repl/reset))))
 
+(defn- parse-options [path-or-options]
+  (merge
+   {:relevant-file? clojure-file?
+    :paths ["src" "resources"]}
+   (if (vector? path-or-options)
+     {:paths path-or-options}
+     path-or-options)))
+
 (defn start-auto-reset
-  "Automatically reset the system when a Clojure or edn file is changed, pass a
-  vector of relative paths or `[\"src\" \"resources\"]` by default"
+  "Automatically reset the system when relevant files have changed.
+
+   Accepts the following options:
+
+   * `:paths`, a list of directories that contain the source files to watch
+   for changes. Defaults to `[\"src\" \"resources\"]`.
+   * `:relevant-file?`, a function that takes a file name and returns a truthy
+   value indicating whether the system should be reset. Defaults to a function
+   that triggers resets for Clojure and EDN files.
+
+   Accepts a vector of directories as options for backward compatibility."
   ([]
-   (start-auto-reset ["src" "resources"]))
-  ([paths]
-   (alter-var-root #'watcher
-                   (fn [watcher]
-                     (when-not (nil? watcher)
-                       (beholder/stop watcher))
-                     (apply beholder/watch auto-reset-handler paths)))))
+   (start-auto-reset {}))
+  ([options]
+   (let [{:keys [paths relevant-file?]} (parse-options options)
+         callback (partial auto-reset-handler relevant-file?)]
+     (alter-var-root #'watcher
+                     (fn [watcher]
+                       (when-not (nil? watcher)
+                         (beholder/stop watcher))
+                       (apply beholder/watch callback paths))))))
 
 (defn stop-auto-reset
   []


### PR DESCRIPTION
Hi Tim,

I noticed that it could take a few seconds before `integrant-repl-autoreload` reacted to changes to files on my laptop. I assume this has something to do with the fact that Hawk cannot use a native implementation of java.nio.file.WatchService on macOS.

I like what your project tries to do, so I looked into this problem to see if I could find a fix. After some experimentation, I found out that https://github.com/nextjournal/beholder performs well and immediately picks up changes to files. After replacing Hawk with Beholder in `integrant-repl-autoreload`, everything worked as you'd expect. I don't know if this is also the case on other operating systems. I assume it is, but I didn't check.

I also wanted to be able to configure which files would make `integrant-repl-autoreload` reset the system. This comes in handy when working with HugSLQ, for example. I've added an option to provide a custom variant of `clojure-file?` so that you can do something like `(start-auto-reset {:relevant-file? (constantly true)})`.

Feel free to do whatever you want with this PR. I'm happy to use my fork from now on, but if you like these changes and merge them, I'll switch back to your original.